### PR TITLE
Fix startup crash on non macOS platforms.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,17 +4,13 @@ const pkg = require('./package')
 
 try {
   require('electron-reloader')(module)
-} catch (err) {}
+} catch (err) { }
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let win
 
 function createWindow() {
-  if (process.platform === 'darwin') {
-    app.dock.setIcon(`${__dirname}/src/static/dock-icon.png`)
-  }
-
   win = new BrowserWindow({
     webPreferences: {
       nodeIntegration: true
@@ -24,6 +20,15 @@ function createWindow() {
     minHeight: 340,
     minWidth: 680
   })
+
+  const iconPath = `${__dirname}/src/static/dock-icon.png`
+  if (process.platform === 'darwin') {
+    // macOS
+    app.dock.setIcon(iconPath)
+  } else {
+    // Windows, Linux, etc.
+    win.setIcon(iconPath)
+  }
 
   // and load the index.html of the app.
   win.loadURL(path.join(`file://${__dirname}`, `${pkg['main-html']}`))
@@ -61,7 +66,7 @@ function createWindow() {
         {
           label: 'Quit',
           accelerator: 'Command+Q',
-          click: function() {
+          click: function () {
             app.quit()
           }
         }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ try {
 let win
 
 function createWindow() {
-  app.dock.setIcon(`${__dirname}/src/static/dock-icon.png`)
+  if (process.platform === 'darwin') {
+    app.dock.setIcon(`${__dirname}/src/static/dock-icon.png`)
+  }
 
   win = new BrowserWindow({
     webPreferences: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6378,6 +6378,58 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "IRC client built with Electron & React",
   "private": true,
   "scripts": {
-    "start": "npm run sass && NODE_ENV=production electron ./",
-    "dev": "npm run sass && NODE_ENV=development electron ./",
+    "start": "npm run sass && cross-env NODE_ENV=production electron ./",
+    "dev": "npm run sass && cross-env NODE_ENV=development electron ./",
     "sass": "node-sass src/sass/app.scss --output src/static/",
     "test": "npm run lint && npm run flow && npm run jest",
     "lint": "eslint src/ test/",
@@ -39,6 +39,7 @@
     "babel-eslint": "10.1.0",
     "babel-jest": "26.3.0",
     "babel-plugin-transform-node-env-inline": "0.4.3",
+    "cross-env": "^7.0.2",
     "electron": "8.2.4",
     "electron-devtools-installer": "3.1.1",
     "electron-packager": "15.1.0",


### PR DESCRIPTION
On Windows and other platforms, there is no dock. This checks for the `darwin` platform on startup and does not utilize the dock if we are not on macOS. Things are still wonky on Windows but I was able to use the app a little bit.